### PR TITLE
fix: update FourMeme swap provider with improved token amount formatting

### DIFF
--- a/examples/basic/src/swap-example-four-meme.ts
+++ b/examples/basic/src/swap-example-four-meme.ts
@@ -112,7 +112,7 @@ async function main() {
   console.log('💱 Example 1: Buy SAFUFOUR');
   const inputResult = await agent.execute({
     input: `
-      Buy 0.0001 BNB to SAFUFOUR on bnb chain with 10 % slippage.
+      Buy 0.0001 BNB to SAFUFOUR on FourMeme bnb chain with 10 % slippage.
       Use the following token addresses:
       SAFUFOUR: 0xcf4eef00d87488d523de9c54bf1ba3166532ddb0
     `,
@@ -122,7 +122,7 @@ async function main() {
   console.log('💱 Example 2: Sell SAFUFOUR');
   const outputResult = await agent.execute({
     input: `
-      Sell 100 SAFUFOUR on bnb chain with 10 % slippage.
+      Sell 100 SAFUFOUR on FourMeme bnb chain with 10 % slippage.
       Use the following token addresses:
       SAFUFOUR: 0xcf4eef00d87488d523de9c54bf1ba3166532ddb0
     `,

--- a/examples/basic/src/swap-example.ts
+++ b/examples/basic/src/swap-example.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import { Agent, Wallet, Network, settings, NetworkType, NetworksConfig } from '@binkai/core';
 import { SwapPlugin } from '@binkai/swap-plugin';
 import { PancakeSwapProvider } from '@binkai/pancakeswap-provider';
+import { OkxProvider } from '@binkai/okx-provider';
 import { FourMemeProvider } from '@binkai/four-meme-provider';
 import { ChainId } from '@pancakeswap/sdk';
 import { PostgresDatabaseAdapter } from '@binkai/postgres-adapter';
@@ -107,12 +108,12 @@ async function main() {
   // Create providers with proper chain IDs
   const pancakeswap = new PancakeSwapProvider(provider, ChainId.BSC);
   const fourMeme = new FourMemeProvider(provider, 56);
-
+  const okx = new OkxProvider(provider, 56);
   // Configure the plugin with supported chains
   await swapPlugin.initialize({
     defaultSlippage: 0.5,
     defaultChain: 'bnb',
-    providers: [pancakeswap, fourMeme],
+    providers: [pancakeswap, fourMeme, okx],
     supportedChains: ['bnb', 'ethereum'], // These will be intersected with agent's networks
   });
   console.log('✓ Swap plugin initialized\n');
@@ -126,9 +127,9 @@ async function main() {
   console.log('💱 Example 1: Buy with exact input amount on BNB Chain');
   const result1 = await agent.execute({
     input: `
-      Buy SAFUFOUR from exactly 0.0001 BNB with 0.5% slippage on bnb chain.
+      Buy BINK from exactly 0.0001 BNB with 0.5% slippage on bnb chain.
       Use the following token addresses:
-       SAFUFOUR: 0xcf4eef00d87488d523de9c54bf1ba3166532ddb0
+       BINK: 0x5fdfaFd107Fc267bD6d6B1C08fcafb8d31394ba1
     `,
   });
   console.log('✓ Swap result:', result1, '\n');
@@ -137,9 +138,9 @@ async function main() {
   console.log('💱 Example 2: Sell with exact output amount on BNB Chain');
   const result2 = await agent.execute({
     input: `
-      Sell exactly 20 SAFUFOUR to BNB with 0.5% slippage on bnb chain.
+      Sell exactly 20 BINK to BNB with 0.5% slippage on bnb chain.
       Use the following token addresses:
-       SAFUFOUR: 0xcf4eef00d87488d523de9c54bf1ba3166532ddb0
+       BINK: 0x5fdfaFd107Fc267bD6d6B1C08fcafb8d31394ba1
     `,
   });
 

--- a/packages/providers/four-meme/src/FourMemeProvider.ts
+++ b/packages/providers/four-meme/src/FourMemeProvider.ts
@@ -126,9 +126,6 @@ export class FourMemeProvider implements ISwapProvider {
       const amountIn =
         params.type === 'input' ? ethers.parseUnits(params.amount, tokenIn.decimals) : undefined;
 
-      const amountOut =
-        params.type === 'input' ? undefined : ethers.parseUnits(params.amount, tokenOut.decimals);
-
       const needToken =
         params.type === 'input' && params.fromToken === CONSTANTS.BNB_ADDRESS
           ? params.toToken
@@ -209,8 +206,8 @@ export class FourMemeProvider implements ISwapProvider {
         fromTokenDecimals: tokenIn.decimals,
         toTokenDecimals: tokenOut.decimals,
         slippage: 10,
-        fromAmount: params.type === 'input' ? amountIn?.toString() || '0' : estimatedCost,
-        toAmount: params.type === 'input' ? estimatedAmount : amountOut?.toString() || '0',
+        fromAmount: ethers.formatUnits(amountIn?.toString() || '0', tokenIn.decimals),
+        toAmount: ethers.formatUnits(estimatedAmount, tokenOut.decimals),
         priceImpact: 0,
         route: ['four-meme'],
         estimatedGas: CONSTANTS.DEFAULT_GAS_LIMIT,

--- a/packages/providers/four-meme/src/FourMemeProvider.ts
+++ b/packages/providers/four-meme/src/FourMemeProvider.ts
@@ -134,6 +134,10 @@ export class FourMemeProvider implements ISwapProvider {
       // Get token info from contract and convert to proper format
       const rawTokenInfo = await this.factory._tokenInfos(needToken);
 
+      if (rawTokenInfo.status !== 0) {
+        throw new Error('Token is not launched');
+      }
+
       const tokenInfo = {
         base: rawTokenInfo.base,
         quote: rawTokenInfo.quote,


### PR DESCRIPTION
- Refactor token amount handling in FourMemeProvider
- Use ethers.formatUnits for consistent decimal formatting
- Update swap example to specify FourMeme BNB chain
- Remove redundant amount calculation logic