### PR TITLE
refactor: update token plugin import to use scoped package

### DIFF
--- a/packages/plugins/swap/src/SwapTool.ts
+++ b/packages/plugins/swap/src/SwapTool.ts
@@ -6,8 +6,8 @@ import { ISwapProvider, SwapQuote, SwapParams } from './types';
 import { validateTokenAddress } from './utils/addressValidation';
 import { parseTokenAmount } from './utils/tokenUtils';
 import { isSolanaNetwork } from './utils/networkUtils';
-import type { TokenInfo } from '../../token/src/types';
-import { defaultTokens } from '../../token/src/data/defaultTokens';
+import type { TokenInfo } from '@binkai/token-plugin';
+import { defaultTokens } from '@binkai/token-plugin';
 
 export interface SwapToolConfig extends IToolConfig {
   defaultSlippage?: number;


### PR DESCRIPTION
- Replace local token plugin imports with @binkai/token-plugin
- Simplify import statements for TokenInfo and defaultTokens
- Maintain existing functionality while improving import modularity