### PR TITLE
feat: update swap example and refactor bridge and swap providers

### DIFF
--- a/examples/basic/src/swap-example-jupiter.ts
+++ b/examples/basic/src/swap-example-jupiter.ts
@@ -129,7 +129,7 @@ async function main() {
   console.log('💱 Example 1: Buy USDC from SOL');
   const inputResult = await agent.execute({
     input: `
-      swap 0.1 USDC to SOL. SOL adress is So11111111111111111111111111111111111111111
+       swap 0.00122223 SOL to trump 
     `,
   });
   console.log('✓ Swap result (input):', inputResult, '\n');

--- a/packages/plugins/bridge/src/BaseBridgeProvider.ts
+++ b/packages/plugins/bridge/src/BaseBridgeProvider.ts
@@ -14,6 +14,7 @@ import {
   getTokenInfo,
   getTokenInfoSolana,
 } from './utils/tokenOperations';
+import { isSolanaNetwork } from './utils/networkUtils';
 
 export type NetworkProvider = Provider | Connection;
 
@@ -199,11 +200,11 @@ export abstract class BaseBridgeProvider implements IBridgeProvider {
     let amountBN;
     if (this.isSolanaNetwork(network)) {
       const provider = this.getSolanaProviderForNetwork(network);
-      amountBN = ethers.parseUnits(amount, decimals);
+      amountBN = parseTokenAmount(amount, decimals);
       balance = await provider.getBalance(new PublicKey(walletAddress));
     } else {
       const provider = this.getEvmProviderForNetwork(network);
-      amountBN = ethers.parseUnits(amount, decimals);
+      amountBN = parseTokenAmount(amount, decimals);
       balance = await provider.getBalance(walletAddress);
     }
 
@@ -247,6 +248,10 @@ export abstract class BaseBridgeProvider implements IBridgeProvider {
 
   protected async getToken(tokenAddress: string, network: NetworkName): Promise<Token> {
     this.validateNetwork(network);
+    if (isSolanaNetwork(network)) {
+      return await getTokenInfoSolana(tokenAddress, network);
+    }
+
     // Use the tokenCache utility instead of manual caching
     return await this.tokenCache.getToken(tokenAddress, network, this.providers, this.getName());
   }

--- a/packages/plugins/swap/src/BaseSwapProvider.ts
+++ b/packages/plugins/swap/src/BaseSwapProvider.ts
@@ -187,11 +187,11 @@ export abstract class BaseSwapProvider implements ISwapProvider {
     let amountBN;
     if (isSolanaNetwork(network)) {
       const provider = this.getSolanaProviderForNetwork(network);
-      amountBN = ethers.parseUnits(amount, decimals);
+      amountBN = parseTokenAmount(amount, decimals);
       balance = await provider.getBalance(new PublicKey(walletAddress));
     } else {
       const provider = this.getEvmProviderForNetwork(network);
-      amountBN = ethers.parseUnits(amount, decimals);
+      amountBN = parseTokenAmount(amount, decimals);
       balance = await provider.getBalance(walletAddress);
     }
 
@@ -237,7 +237,7 @@ export abstract class BaseSwapProvider implements ISwapProvider {
   protected async getToken(tokenAddress: string, network: NetworkName): Promise<Token> {
     this.validateNetwork(network);
     if (isSolanaNetwork(network)) {
-      // TODO: Implement Solana
+      return await getTokenInfoSolana(tokenAddress, network);
     }
     // Use the tokenCache utility instead of manual caching
     return await this.tokenCache.getToken(tokenAddress, network, this.providers, this.getName());

--- a/packages/providers/jupiter/src/JupiterProvider.ts
+++ b/packages/providers/jupiter/src/JupiterProvider.ts
@@ -102,7 +102,7 @@ export class JupiterProvider extends BaseSwapProvider {
       const response = await this.api.post<JupiterSwapResponse>('/swap?swapType=aggregator', {
         addConsensusAccount: false,
         allowOptimizedWrappedSolTokenAccount: true,
-        asLegacyTransaction: this.checkHaveNativeToken(params),
+        asLegacyTransaction: false,
         correctLastValidBlockHeight: true,
         dynamicComputeUnitLimit: true,
         prioritizationFeeLamports: {


### PR DESCRIPTION
- Modify swap example to demonstrate swapping SOL to a new token.
- Refactor BaseBridgeProvider and BaseSwapProvider to use parseTokenAmount for amount conversion.
- Implement token retrieval for Solana network in both providers.
- Adjust JupiterProvider to disable legacy transaction handling.