### PR TITLE
feat: add support for Solana and Ethereum networks in wallet example

### DIFF
--- a/examples/basic/src/wallet-example.ts
+++ b/examples/basic/src/wallet-example.ts
@@ -18,10 +18,24 @@ import { TokenPlugin } from '@binkai/token-plugin';
 
 async function main() {
   const BNB_RPC = 'https://bsc-dataseed1.binance.org';
+  const SOL_RPC = 'https://api.mainnet-beta.solana.com';
+  const ETH_RPC = 'https://eth.llamarpc.com';
 
   // Define available networks
   console.log('📡 Configuring networks...');
   const networks: NetworksConfig['networks'] = {
+    [NetworkName.SOLANA]: {
+      type: 'solana' as NetworkType,
+      config: {
+        rpcUrl: SOL_RPC,
+        name: 'Solana',
+        nativeCurrency: {
+          name: 'Solana',
+          symbol: 'SOL',
+          decimals: 9,
+        },
+      },
+    },
     bnb: {
       type: 'evm' as NetworkType,
       config: {
@@ -31,6 +45,19 @@ async function main() {
         nativeCurrency: {
           name: 'BNB',
           symbol: 'BNB',
+          decimals: 18,
+        },
+      },
+    },
+    ethereum: {
+      type: 'evm' as NetworkType,
+      config: {
+        chainId: 1,
+        rpcUrl: ETH_RPC,
+        name: 'Ethereum',
+        nativeCurrency: {
+          name: 'Ether',
+          symbol: 'ETH',
           decimals: 18,
         },
       },
@@ -57,7 +84,8 @@ async function main() {
   console.log('✓ Wallet created\n');
 
   console.log('🤖 Wallet BNB:', await wallet.getAddress(NetworkName.BNB));
-
+  console.log('🤖 Wallet ETH:', await wallet.getAddress(NetworkName.ETHEREUM));
+  console.log('🤖 Wallet SOL:', await wallet.getAddress(NetworkName.SOLANA));
   // Create and configure the wallet plugin
   console.log('🔄 Initializing wallet plugin...');
   const walletPlugin = new WalletPlugin();
@@ -72,9 +100,9 @@ async function main() {
 
   // Initialize plugin with provider
   await walletPlugin.initialize({
-    defaultChain: 'bnb',
+    // defaultChain: 'bnb',
     providers: [bnbProvider, birdeyeProvider],
-    supportedChains: ['bnb'],
+    supportedChains: ['bnb', 'solana', 'etherum'],
   });
 
   // Create and configure the swap plugin
@@ -135,7 +163,7 @@ async function main() {
     //    BINKAI: 0x5fdfaFd107Fc267bD6d6B1C08fcafb8d31394ba1
     // `,
     input: `
-      Buy Broccoli from half of my wallet balance on bnb chain`,
+      my wallet balance on BNB chain`,
     //   input: `
     //   Buy BINK from with 0.5 bnb from my wallet.
     //   Use the following token addresses:

--- a/packages/plugins/wallet/src/WalletBalanceTool.ts
+++ b/packages/plugins/wallet/src/WalletBalanceTool.ts
@@ -45,13 +45,13 @@ export function mergeObjects<T extends Record<string, any>>(obj1: T, obj2: T): T
 
 export class GetWalletBalanceTool extends BaseTool {
   public registry: ProviderRegistry;
-  private defaultNetwork: string;
+  // private defaultNetwork: string;
   private supportedNetworks: Set<string>;
 
   constructor(config: WalletToolConfig) {
     super(config);
     this.registry = new ProviderRegistry();
-    this.defaultNetwork = config.defaultNetwork || 'bnb';
+    // this.defaultNetwork = config.defaultNetwork || 'bnb';
     this.supportedNetworks = new Set<string>(config.supportedNetworks || []);
   }
 
@@ -70,7 +70,7 @@ export class GetWalletBalanceTool extends BaseTool {
   getDescription(): string {
     const providers = this.registry.getProviderNames().join(', ');
     const networks = Array.from(this.supportedNetworks).join(', ');
-    return `Get detailed information about tokens and native currencies in a wallet. Shows balances of all tokens (ERC20, NFTs) and native currencies (ETH, BNB, etc.) that a wallet holds, including token balances, token addresses, symbols, and decimals. Supports networks: ${networks}. Available providers: ${providers}. Use this tool when you need to check what tokens or coins a wallet contains, their balances, and detailed token information.`;
+    return `Get detailed information about tokens and native currencies in a wallet. Shows balances of all tokens (ERC20, NFTs) and native currencies (ETH, BNB, SOL, etc.) that a wallet holds of all network (Solana, Etherum, BNB), including token balances, token addresses, symbols, and decimals. Supports networks: ${networks}. Available providers: ${providers}. Use this tool when you need to check what tokens or coins a wallet contains, their balances, and detailed token information.`;
   }
 
   private getsupportedNetworks(): string[] {
@@ -92,7 +92,7 @@ export class GetWalletBalanceTool extends BaseTool {
         .describe('The wallet address to query (optional - uses agent wallet if not provided)'),
       network: z
         .enum(supportedNetworks as [string, ...string[]])
-        .default(this.defaultNetwork)
+        // .default(this.defaultNetwork)
         .describe('The blockchain to query the wallet on'),
     });
   }
@@ -109,7 +109,7 @@ export class GetWalletBalanceTool extends BaseTool {
         onProgress?: (data: ToolProgress) => void,
       ) => {
         try {
-          const network = args.network || this.defaultNetwork;
+          const network = args.network;
           let address = args.address;
 
           // If no address provided, get it from the agent's wallet
@@ -165,7 +165,7 @@ export class GetWalletBalanceTool extends BaseTool {
           return JSON.stringify({
             status: 'error',
             message: error instanceof Error ? error.message : String(error),
-            network: args.network || this.defaultNetwork,
+            network: args.network,
           });
         }
       },

--- a/packages/plugins/wallet/src/WalletPlugin.ts
+++ b/packages/plugins/wallet/src/WalletPlugin.ts
@@ -28,12 +28,12 @@ export class WalletPlugin extends BasePlugin {
     }
 
     this.walletTool = new GetWalletBalanceTool({
-      defaultNetwork: config.defaultNetwork,
+      // defaultNetwork: config.defaultNetwork,
       supportedNetworks: Array.from(this.supportedNetworks),
     });
 
     this.transferTool = new TransferTool({
-      defaultNetwork: config.defaultNetwork,
+      // defaultNetwork: config.defaultNetwork,
       supportedNetworks: Array.from(this.supportedNetworks),
     });
 


### PR DESCRIPTION
- Introduced Solana and Ethereum network configurations in wallet-example.ts.
- Updated wallet balance tool to reflect support for SOL and ETH in descriptions and functionality.
- Removed default network references to streamline configuration handling.